### PR TITLE
fix(heap): comparison func in extract test

### DIFF
--- a/heap/heap_test.go
+++ b/heap/heap_test.go
@@ -43,7 +43,7 @@ func TestMinHeapExtract(t *testing.T) {
 	heap.Insert(min[int], 99)
 	heap.Insert(min[int], want)
 
-	got, ok := heap.Extract(max[int])
+	got, ok := heap.Extract(min[int])
 
 	if !ok {
 		t.Errorf("error extracting item from heap")


### PR DESCRIPTION
Fix a small copy/paste bug in the heap extract test. 
The interesting thing is that using a wrong comparison function will break other consecutive extract calls, but will return the correct value.  So maybe it is better to just keep the test that extracts all the elements and then check the order.

ps. there wasn't any contribution guidelines so I hope this PR is ok 😄 